### PR TITLE
Fix type hint for item list route

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from typing import List
 from .. import schemas, crud, models, database
 
 router = APIRouter()
@@ -10,7 +11,7 @@ def create_item(item: schemas.ItemCreate, db: Session = Depends(database.get_db)
     return crud.create_item(db=db, item=item)
 
 # Obtener todos los ítems
-@router.get("/items/", response_model=list[schemas.Item])
+@router.get("/items/", response_model=List[schemas.Item])
 def get_items(db: Session = Depends(database.get_db)):
     return crud.get_items(db)
 


### PR DESCRIPTION
## Summary
- fix typing for `get_items` to use `List` from `typing`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn app.main:app --reload` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e7a3567f4832298d81ac20afd5484